### PR TITLE
Add Alternate Current mod

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -3,3 +3,7 @@ hash-format = "sha256"
 [[files]]
 file = "mods/ai-improvements.pw.toml"
 metafile = true
+
+[[files]]
+file = "mods/alternate-current.pw.toml"
+metafile = true

--- a/mods/alternate-current.pw.toml
+++ b/mods/alternate-current.pw.toml
@@ -1,0 +1,13 @@
+name = "Alternate Current"
+filename = "alternate-current-mc1.19-1.5.0.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "e3cea9e171c7edb2a3868e83a9c8264ea5b51c84"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 4406066
+project-id = 548115


### PR DESCRIPTION
Add [Alternate Current][1] v1.5.0. This mod implements some performance-improving modifications to redstone dust.

These changes are minimally-invasive, but the mod author warns that location-dependent redstone contraptions may not work. I think this is a reasonable compromise for performance anyway.

[1]: https://www.curseforge.com/minecraft/mc-mods/alternate-current