### PR TITLE
Add Clumps mod

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -7,3 +7,7 @@ metafile = true
 [[files]]
 file = "mods/alternate-current.pw.toml"
 metafile = true
+
+[[files]]
+file = "mods/clumps.pw.toml"
+metafile = true

--- a/mods/clumps.pw.toml
+++ b/mods/clumps.pw.toml
@@ -1,0 +1,13 @@
+name = "Clumps"
+filename = "Clumps-forge-1.19.2-9.0.0+14.jar"
+side = "server"
+
+[download]
+hash-format = "sha1"
+hash = "fa1ea47e0da5a219355bd5b6cf5df6e821b2baf8"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 4153347
+project-id = 256717


### PR DESCRIPTION
Add [Clumps][1] v9.0.0+14. This mod is a performance-improving mod which clumps together XP orbs into a single entity to reduce lag.

This mod is installed on the server side only.

[1]: https://www.curseforge.com/minecraft/mc-mods/clumps