### PR TITLE
Include Clumps client-side

### DIFF
--- a/mods/clumps.pw.toml
+++ b/mods/clumps.pw.toml
@@ -1,6 +1,6 @@
 name = "Clumps"
 filename = "Clumps-forge-1.19.2-9.0.0+14.jar"
-side = "server"
+side = "both"
 
 [download]
 hash-format = "sha1"


### PR DESCRIPTION
While Clumps is a server-side modification, it still benefits the internal server used when running in single-player.