### PR TITLE
Add Farsight mod

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -11,3 +11,7 @@ metafile = true
 [[files]]
 file = "mods/clumps.pw.toml"
 metafile = true
+
+[[files]]
+file = "mods/farsight.pw.toml"
+metafile = true

--- a/mods/farsight.pw.toml
+++ b/mods/farsight.pw.toml
@@ -1,0 +1,13 @@
+name = "Farsight [Forge]"
+filename = "farsight-1.19.2-2.1.jar"
+side = "client"
+
+[download]
+hash-format = "sha1"
+hash = "e96e0f29875881b19bedbc991c69687be812d1c7"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 4017307
+project-id = 495693


### PR DESCRIPTION
Add [Farsight][1] v2.1. This mod is a client-side modification that caches chunks received from a server and renders them even if they are outside of the server's view distance.

[1]: https://www.curseforge.com/minecraft/mc-mods/farsight