### PR TITLE
Add Entity Culling mod

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -17,5 +17,9 @@ file = "mods/dynamic-view.pw.toml"
 metafile = true
 
 [[files]]
+file = "mods/entityculling.pw.toml"
+metafile = true
+
+[[files]]
 file = "mods/farsight.pw.toml"
 metafile = true

--- a/mods/entityculling.pw.toml
+++ b/mods/entityculling.pw.toml
@@ -1,0 +1,13 @@
+name = "Entity Culling Fabric/Forge"
+filename = "entityculling-forge-1.6.1-mc1.19.2.jar"
+side = "client"
+
+[download]
+hash-format = "sha1"
+hash = "2b2545ea2e203b25d9b33be1e5b8aea38eaa90f2"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 4404949
+project-id = 448233


### PR DESCRIPTION
Add [Entity Culling][1] v1.6.1. This is a small client-side mod which culls entities that are not in a direct line of sight. This may require some configuration tweaking for blocks introduced by other mods in the future.

[1]: https://www.curseforge.com/minecraft/mc-mods/entityculling