### PR TITLE
Add Entity Collision FPS Fix mod

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -17,5 +17,9 @@ file = "mods/dynamic-view.pw.toml"
 metafile = true
 
 [[files]]
+file = "mods/entity-collision-fps-fix.pw.toml"
+metafile = true
+
+[[files]]
 file = "mods/farsight.pw.toml"
 metafile = true

--- a/mods/entity-collision-fps-fix.pw.toml
+++ b/mods/entity-collision-fps-fix.pw.toml
@@ -1,0 +1,13 @@
+name = "Entity Collision FPS Fix"
+filename = "Entity_Collision_FPS_Fix-forge-1.19-2.0.0.0.jar"
+side = "client"
+
+[download]
+hash-format = "sha1"
+hash = "ca1f804f071f6a4567922be16ab8fd65cf817b70"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 3829972
+project-id = 628345


### PR DESCRIPTION
Add [Entity Collision FPS Fix][1] v2.0.0.0. This is a small client-side mod which stops the client from running entity collision checks that the server is already responsible for.

[1]: https://www.curseforge.com/minecraft/mc-mods/entity-collision-fps-fix