### PR TITLE
Add FastFurnace, FastSuite and FastWorkbench mods

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -33,5 +33,9 @@ file = "mods/fastsuite.pw.toml"
 metafile = true
 
 [[files]]
+file = "mods/fastworkbench.pw.toml"
+metafile = true
+
+[[files]]
 file = "mods/placebo.pw.toml"
 metafile = true

--- a/index.toml
+++ b/index.toml
@@ -29,5 +29,9 @@ file = "mods/fastfurnace.pw.toml"
 metafile = true
 
 [[files]]
+file = "mods/fastsuite.pw.toml"
+metafile = true
+
+[[files]]
 file = "mods/placebo.pw.toml"
 metafile = true

--- a/index.toml
+++ b/index.toml
@@ -25,5 +25,9 @@ file = "mods/farsight.pw.toml"
 metafile = true
 
 [[files]]
+file = "mods/fastfurnace.pw.toml"
+metafile = true
+
+[[files]]
 file = "mods/placebo.pw.toml"
 metafile = true

--- a/index.toml
+++ b/index.toml
@@ -23,3 +23,7 @@ metafile = true
 [[files]]
 file = "mods/farsight.pw.toml"
 metafile = true
+
+[[files]]
+file = "mods/placebo.pw.toml"
+metafile = true

--- a/mods/fastfurnace.pw.toml
+++ b/mods/fastfurnace.pw.toml
@@ -1,0 +1,13 @@
+name = "FastFurnace"
+filename = "FastFurnace-1.19.2-7.0.0.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "3135756b5a0b8f34643f34ad2807f3a32a7b041e"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 4028348
+project-id = 299540

--- a/mods/fastsuite.pw.toml
+++ b/mods/fastsuite.pw.toml
@@ -1,0 +1,13 @@
+name = "FastSuite"
+filename = "FastSuite-1.19.2-4.0.0.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "a831b43b8fec6180ab1a9e8fc39812254d0fecc3"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 4028357
+project-id = 475117

--- a/mods/fastworkbench.pw.toml
+++ b/mods/fastworkbench.pw.toml
@@ -1,0 +1,13 @@
+name = "FastWorkbench"
+filename = "FastWorkbench-1.19.2-7.0.1.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "d767e63dd3856c68a3f589565609808865973d2d"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 4029996
+project-id = 288885

--- a/mods/placebo.pw.toml
+++ b/mods/placebo.pw.toml
@@ -1,0 +1,13 @@
+name = "Placebo"
+filename = "Placebo-1.19.2-7.1.7.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "3e351d1904e9761e6e6d1eecedf1fd1b2a40da61"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 4452975
+project-id = 283644


### PR DESCRIPTION
Add [FastFurnace][1] v7.0.0, [FastSuite][2] v7.0.1 and [FastWorkbench][3] v7.0.1. These are performance-improving mods which focus on caching last-used recipes in various crafting stations

Also add [Placebo][4] v7.1.7, which is a dependency of all three.

[1]: https://www.curseforge.com/minecraft/mc-mods/fastfurnace
[2]: https://www.curseforge.com/minecraft/mc-mods/fastsuite
[3]: https://www.curseforge.com/minecraft/mc-mods/fastworkbench
[4]: https://www.curseforge.com/minecraft/mc-mods/placebo