### PR TITLE
Add Canary mod

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -9,6 +9,10 @@ file = "mods/alternate-current.pw.toml"
 metafile = true
 
 [[files]]
+file = "mods/canary.pw.toml"
+metafile = true
+
+[[files]]
 file = "mods/clumps.pw.toml"
 metafile = true
 

--- a/mods/canary.pw.toml
+++ b/mods/canary.pw.toml
@@ -1,0 +1,13 @@
+name = "Canary"
+filename = "canary-mc1.19.2-0.1.9.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "1c241937c961ed6311578551152e23bc08bb2ab0"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 4421576
+project-id = 665658


### PR DESCRIPTION
Add [Canary][1] v0.1.9. Similarly to FerriteCore, this is a performance-improving mod which makes various algorithmic improvements to some of the deeper parts of the Minecraft codebase.

[1]: https://www.curseforge.com/minecraft/mc-mods/canary