### PR TITLE
Add LazyDFU mod

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -45,5 +45,9 @@ file = "mods/ferritecore.pw.toml"
 metafile = true
 
 [[files]]
+file = "mods/lazy-dfu-forge.pw.toml"
+metafile = true
+
+[[files]]
 file = "mods/placebo.pw.toml"
 metafile = true

--- a/mods/lazy-dfu-forge.pw.toml
+++ b/mods/lazy-dfu-forge.pw.toml
@@ -1,0 +1,13 @@
+name = "Lazy DataFixerUpper(LazyDFU) [FORGE]"
+filename = "lazydfu-1.19-1.0.2.jar"
+side = "client"
+
+[download]
+hash-format = "sha1"
+hash = "e120fbcc1704fcf0e661494771ba50ffe5a43b40"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 4327266
+project-id = 460819


### PR DESCRIPTION
Add [LazyDFU][1] v1.0.2. This mod reduces the time it takes to boot Minecraft by deferring the DataFixerUpper until they are necessary (i.e. when loading a world from an older version of Minecraft).

This is already implemented in Vanilla for servers, so this mod is made client-only.

[1]: https://www.curseforge.com/minecraft/mc-mods/lazy-dfu-forge