### PR TITLE
Add Rubidium mod

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -59,3 +59,7 @@ metafile = true
 [[files]]
 file = "mods/radon.pw.toml"
 metafile = true
+
+[[files]]
+file = "mods/rubidium.pw.toml"
+metafile = true

--- a/mods/rubidium.pw.toml
+++ b/mods/rubidium.pw.toml
@@ -1,0 +1,13 @@
+name = "Rubidium"
+filename = "rubidium-0.6.2a.jar"
+side = "client"
+
+[download]
+hash-format = "sha1"
+hash = "10279cd20734b108282498d951dde1c0bd60c367"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 4448157
+project-id = 574856


### PR DESCRIPTION
Add [Rubidium][1] v0.6.2a. This client-side mod makes a number of performance-oriented changes to the rendering engine.

[1]: https://www.curseforge.com/minecraft/mc-mods/rubidium