### PR TITLE
Add Starlight mod

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -67,3 +67,7 @@ metafile = true
 [[files]]
 file = "mods/saturn.pw.toml"
 metafile = true
+
+[[files]]
+file = "mods/starlight-forge.pw.toml"
+metafile = true

--- a/mods/starlight-forge.pw.toml
+++ b/mods/starlight-forge.pw.toml
@@ -1,0 +1,13 @@
+name = "Starlight (Forge)"
+filename = "starlight-1.1.1+forge.cf5b10b.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "3d80b848c966841deeeba70305e38a29b7e3788d"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 3836016
+project-id = 526854


### PR DESCRIPTION
Add [Starlight][1] v1.1.1. This is a total overhaul of the vanilla lighting engine, so it's possible we will see incompatibilities with other mods down the line. It plays fine with Canary, but we need to keep an eye out for issues.

[1]: https://www.curseforge.com/minecraft/mc-mods/starlight-forge