### PR TITLE
Add Smooth Chunk Save mod

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -69,5 +69,9 @@ file = "mods/saturn.pw.toml"
 metafile = true
 
 [[files]]
+file = "mods/smooth-chunk-save.pw.toml"
+metafile = true
+
+[[files]]
 file = "mods/starlight-forge.pw.toml"
 metafile = true

--- a/mods/smooth-chunk-save.pw.toml
+++ b/mods/smooth-chunk-save.pw.toml
@@ -1,0 +1,13 @@
+name = "Server Performance - Smooth Chunk Save[Forge/Fabric]"
+filename = "smoothchunk-1.19.1-2.0.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "e872ae6a83ad4d7cbb022101dbb48a6b1bea18a0"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 3922654
+project-id = 582327


### PR DESCRIPTION
Add [Smooth Chunk Save][1] v2.0. This is a small performance-focused mod which amortises the load of chunk saving.

[1]: https://www.curseforge.com/minecraft/mc-mods/smooth-chunk-save