### PR TITLE
Add Attribute Fix mod

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -9,6 +9,10 @@ file = "mods/alternate-current.pw.toml"
 metafile = true
 
 [[files]]
+file = "mods/attributefix.pw.toml"
+metafile = true
+
+[[files]]
 file = "mods/canary.pw.toml"
 metafile = true
 

--- a/mods/attributefix.pw.toml
+++ b/mods/attributefix.pw.toml
@@ -1,0 +1,13 @@
+name = "AttributeFix"
+filename = "AttributeFix-Forge-1.19.2-17.2.6.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "b8521ee0107ead81e97d2889f0a26ae57f9029e2"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 4436598
+project-id = 280510


### PR DESCRIPTION
Add [Attribute Fix][1] v17.2.6. This fixes certain mods which exceed the caps on various attributes (e.g. health, attack damage, armour values, etc.).

[1]: https://www.curseforge.com/minecraft/mc-mods/attributefix