### PR TITLE
Add Xaero's Minimap and Xaero's World Map mods

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -79,3 +79,7 @@ metafile = true
 [[files]]
 file = "mods/starlight-forge.pw.toml"
 metafile = true
+
+[[files]]
+file = "mods/xaeros-minimap.pw.toml"
+metafile = true

--- a/index.toml
+++ b/index.toml
@@ -83,3 +83,7 @@ metafile = true
 [[files]]
 file = "mods/xaeros-minimap.pw.toml"
 metafile = true
+
+[[files]]
+file = "mods/xaeros-world-map.pw.toml"
+metafile = true

--- a/mods/xaeros-minimap.pw.toml
+++ b/mods/xaeros-minimap.pw.toml
@@ -1,0 +1,13 @@
+name = "Xaero's Minimap"
+filename = "Xaeros_Minimap_23.3.2_Forge_1.19.1.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "81bedfdcb9ccc03a1f9852847015e2a480afc217"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 4454639
+project-id = 263420

--- a/mods/xaeros-world-map.pw.toml
+++ b/mods/xaeros-world-map.pw.toml
@@ -1,0 +1,13 @@
+name = "Xaero's World Map"
+filename = "XaerosWorldMap_1.29.4_Forge_1.19.1.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "9a550ba182584cc5c56e267d7a85f521b72fac60"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 4454662
+project-id = 317780


### PR DESCRIPTION
Add [Xaero's Minimap][1] v23.3.2 and [Xaero's World Map][2] v1.29.4. These mods add map support to the game, the former through a minimap and the latter through a larger world map.

[1]: https://www.curseforge.com/minecraft/mc-mods/xaeros-minimap
[2]: https://www.curseforge.com/minecraft/mc-mods/xaeros-world-map