### PR TITLE
Add Just Enough Items (JEI), Professions (JEP) and Resources (JER) mods

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -57,6 +57,10 @@ file = "mods/just-enough-professions-jep.pw.toml"
 metafile = true
 
 [[files]]
+file = "mods/just-enough-resources-jer.pw.toml"
+metafile = true
+
+[[files]]
 file = "mods/lazy-dfu-forge.pw.toml"
 metafile = true
 

--- a/index.toml
+++ b/index.toml
@@ -49,6 +49,10 @@ file = "mods/ferritecore.pw.toml"
 metafile = true
 
 [[files]]
+file = "mods/jei.pw.toml"
+metafile = true
+
+[[files]]
 file = "mods/lazy-dfu-forge.pw.toml"
 metafile = true
 

--- a/index.toml
+++ b/index.toml
@@ -53,6 +53,10 @@ file = "mods/jei.pw.toml"
 metafile = true
 
 [[files]]
+file = "mods/just-enough-professions-jep.pw.toml"
+metafile = true
+
+[[files]]
 file = "mods/lazy-dfu-forge.pw.toml"
 metafile = true
 

--- a/mods/jei.pw.toml
+++ b/mods/jei.pw.toml
@@ -1,0 +1,13 @@
+name = "Just Enough Items (JEI)"
+filename = "jei-1.19.2-forge-11.6.0.1013.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "2a4e725f2722749518e3f500efbcd9b83a6c6054"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 4434397
+project-id = 238222

--- a/mods/just-enough-professions-jep.pw.toml
+++ b/mods/just-enough-professions-jep.pw.toml
@@ -1,0 +1,13 @@
+name = "Just Enough Professions (JEP)"
+filename = "JustEnoughProfessions-forge-1.19.2-2.0.2.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "9e367c52189f188bec750e6596d29f81d1d8486e"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 4427313
+project-id = 417645

--- a/mods/just-enough-resources-jer.pw.toml
+++ b/mods/just-enough-resources-jer.pw.toml
@@ -1,0 +1,13 @@
+name = "Just Enough Resources (JER)"
+filename = "JustEnoughResources-1.19.2-1.2.2.200.jar"
+side = "both"
+
+[download]
+hash-format = "sha1"
+hash = "c55206249be5edf1e09609ddc15485caba6c0f96"
+mode = "metadata:curseforge"
+
+[update]
+[update.curseforge]
+file-id = 4440341
+project-id = 240630


### PR DESCRIPTION
Add [Just Enough Items (JEI)][1] v11.6.0.1013, [Just Enough Professions (JEP)][2] v2.0.2 and [Just Enough Resources (JER)][3] v1.2.2.200. JEI adds a GUI overlay to the client which allows you to view items and recipes. JEP and JER add additional information to JEI focused on villager professions and drops/resources respectively.

[1]: https://www.curseforge.com/minecraft/mc-mods/jei
[2]: https://www.curseforge.com/minecraft/mc-mods/just-enough-professions-jep
[3]: https://www.curseforge.com/minecraft/mc-mods/just-enough-resources-jer